### PR TITLE
Fix pre-existing Sphinx -W build warnings

### DIFF
--- a/docs/available_services/chatdnp.md
+++ b/docs/available_services/chatdnp.md
@@ -10,24 +10,24 @@ ChatDNP is the Douglas Neuroinformatics Platform’s (DNP) local AI chat service
 - Dual Intel Xeon Gold 6526Y (32 cores / 54 threads)
 - 2 NUMA nodes
 
-### Why have a local (Institution) chat?
+## Why have a local (Institution) chat?
 
 - **Privacy:** Keeps sensitive discussion inside the institutional boundary. Ability to include anonymized participant info and files in chats.
 - **Performance:** Dedicated GPUs for low-latency responses.
 - **Control:** Model selection, updates, and administration are managed by DNP.
 
-### Who can use it
+## Who can use it
 
 - Anyone on the Douglas Research Centre internal network.
 - External access is not available.
 
-### How to sign in
+## How to sign in
 
 1. Navigate to chatDNP: https://chatdnp.douglas.rtss.qc.ca
 2. Accept the privacy warning of the site not being secure (we use self-signed certs not open to the web)
 2. Read the disclaimer and accept our terms of use.
 
-### Privacy & Data Use
+## Privacy & Data Use
 
 Your chat prompts and responses are recorded so we can improve the platform. **Please do not paste credentials, tokens, or personal passwords.** Some important things to consider:
 
@@ -38,7 +38,7 @@ Your chat prompts and responses are recorded so we can improve the platform. **P
 - **API access:** Disabled by default, it is only available to authorized projects.
 - **Private chat account:** Should you require your own private chat (with history), please contact us detailing the specifics.
 
-### Open WebUI Quick Start Usage
+## Open WebUI Quick Start Usage
 
 1. Start a new chat by clicking the **New chat** button (top left pane).
 2. **Select a model** from the drop-down list (top centre of the chat window).

--- a/docs/using_the_system/index.md
+++ b/docs/using_the_system/index.md
@@ -16,4 +16,5 @@ access_to_system.md
 remote_access.md
 access_to_data.md
 access_to_software.md
+running_docker.md
 security.md


### PR DESCRIPTION
- chatdnp.md: demote section headings H3->H2 (file jumped H1->H3)
- using_the_system/index.md: add running_docker.md to toctree (was orphaned)

Clears the 6 warnings that fail the html docs CI job under sphinx-build -W.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and structure of service documentation
  * Added Docker deployment documentation to the system guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->