### PR TITLE
Fix stale docs build and remove example workstation hostname

### DIFF
--- a/docs/research_methods/sharing_data.md
+++ b/docs/research_methods/sharing_data.md
@@ -131,7 +131,7 @@ To prepare your data for sharing, you should:
 
 ### Sharing data in support of a published manuscript
 
-Let's assume you have just finished the manuscript for an exciting research project (✨ congrats ✨)
+Let's assume you have just finished the manuscript for an exciting research project (congrats!)
 and now you want to share the data that support your central findings and figures together
 with the manuscript.
 This is not only a great way to ensure that other can follow and re-use your research 

--- a/docs/using_the_system/access_to_system.md
+++ b/docs/using_the_system/access_to_system.md
@@ -46,7 +46,7 @@ To use VS Code’s **Remote-SSH** feature to connect to internal hosts, it is **
 
 ```{admonition} Notes on Connecting via the Gateway
 When connecting to the gateway directly, you are automatically redirected to `cicus03`.  
-To access a different host (e.g., `cicws01`), you **must** use the jump host flag (`-J`) and explicitly specify the desired destination in your SSH command.
+To access a different host (e.g., `cicwsXX`), you **must** use the jump host flag (`-J`) and explicitly specify the desired destination in your SSH command.
 ```
 
 Please follow these steps to properly configure VS Code’s Remote SSH extension:

--- a/docs/using_the_system/index.md
+++ b/docs/using_the_system/index.md
@@ -16,5 +16,4 @@ access_to_system.md
 remote_access.md
 access_to_data.md
 access_to_software.md
-running_docker.md
 security.md

--- a/docs/using_the_system/running_docker.md
+++ b/docs/using_the_system/running_docker.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Running Docker
 
 Docker is installed on the DNP system. However, for security reasons, it must be configured to run in non-root mode.


### PR DESCRIPTION
- Remove emoji from sharing_data.md that broke the PDF (pdflatex) build, which was causing ReadTheDocs to fail every build and serve a stale site missing the Remote Access page (#97).
- Replace example hostname cicws01 with placeholder cicwsXX so users don't all funnel to one workstation (#94).
- Remove Running Docker from the toctree (shared by URL only) and mark it orphan to avoid a build warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Generalized SSH connection examples in system access guide
  * Updated documentation navigation structure
  * Enhanced Docker setup documentation with additional introductory content
  * Minor formatting updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->