### PR TITLE
CI: bump checkout to v4 and rebuild docs on push to master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,15 @@
-name: "Pull Request Docs Check"
-on: 
-- pull_request
+name: "Docs Check"
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
@@ -14,7 +17,7 @@ jobs:
   linkcheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"


### PR DESCRIPTION
- actions/checkout@v1 -> @v4 (v1 is deprecated and produced spurious "couldn't find remote ref refs/pull/N/merge" checkout failures)
- Also run the docs and linkcheck builds on push to master, so master is rebuilt after every merge instead of only on pull_request. Previously broken files could merge and then break every subsequent PR's full-tree build. Renamed the workflow to "Docs Check" to reflect both triggers.